### PR TITLE
Switch to LTS .NET dependency for AMWin-RP

### DIFF
--- a/bucket/AMWin-RP.json
+++ b/bucket/AMWin-RP.json
@@ -2,7 +2,7 @@
     "version": "1.4.9",
     "description": "A Discord Rich Presence client for Apple Music's native Windows app.",
     "license": "GPL-3.0",
-    "depends": "main/dotnet-sdk",
+    "depends": "versions/dotnet-sdk-lts",
     "url": "https://github.com/PKBeam/AMWin-RP/releases/download/v1.4.9/AMWin-RichPresence-v1.4.9-NoRuntime.zip",
     "bin": "AMWin-RichPresence.exe",
     "shortcuts": [[


### PR DESCRIPTION
Fixes this issue on launch:

![Screenshot 2025-02-11 162537](https://github.com/user-attachments/assets/a4512b91-2d76-4ce4-a623-78bbb6c64943)

See https://github.com/PKBeam/AMWin-RP/issues/168

Note to self: Drop AMWin-RP if they haven't updated to a supported LTS release when .NET 8.x is no longer supported (November 10, 2026). See https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core